### PR TITLE
When checking kubectl version, do it offline via --client flag

### DIFF
--- a/hyperion/kube_util.py
+++ b/hyperion/kube_util.py
@@ -8,7 +8,9 @@ from .common import HyperionCLIException
 
 def kubectl_version():
     try:
-        check_call(['kubectl', 'version'], stdout=DEVNULL, stderr=DEVNULL)
+        # Use --client flag so that we check the ctl client version only.
+        # Without this flag, kubectl also checks the cluster version.
+        check_call(['kubectl', 'version', '--client'], stdout=DEVNULL, stderr=DEVNULL)
     except CalledProcessError:
         raise HyperionCLIException('kubectl is not installed')
 


### PR DESCRIPTION
Without it, cli reported that kubectl was not installed only
because a VPN connection to the cluster was not working.

Closes #6 